### PR TITLE
Fix Mono Widget Retain Cycle

### DIFF
--- a/Sources/ConnectIOS/MonoViewController.swift
+++ b/Sources/ConnectIOS/MonoViewController.swift
@@ -126,17 +126,25 @@ extension MonoViewController: WKScriptMessageHandler {
             switch type {
             case "mono.connect.widget.account_linked":
                 self.successHandler(data?["code"] as! String)
-                self.dismiss(animated: true, completion: nil)
+                self.dismiss(animated: true, completion: { [weak self] in
+                    self?.removeScriptMessageHandler(for: userContentController)
+                })
                 break
             case "mono.connect.widget.closed":
                 self.closeHandler()
-                self.dismiss(animated: true, completion: nil)
+                self.dismiss(animated: true, completion: { [weak self] in
+                    self?.removeScriptMessageHandler(for: userContentController)
+                })
                 break
             default:
                 self.dismiss(animated: true, completion: nil)
                 break
             }
         }
+    }
+    
+    private func removeScriptMessageHandler(for userContentController: WKUserContentController) {
+        userContentController.removeScriptMessageHandler(forName: "mono")
     }
 }
 

--- a/Sources/ConnectKit/MonoWidget.swift
+++ b/Sources/ConnectKit/MonoWidget.swift
@@ -200,19 +200,27 @@ extension MonoWidget: WKScriptMessageHandler {
             switch type {
             case "mono.connect.widget.account_linked":
                 self.successHandler(data?["code"] as! String)
-                self.dismiss(animated: true, completion: nil)
+                self.dismiss(animated: true, completion: { [weak self] in
+                    self?.removeScriptMessageHandler(for: userContentController)
+                })
                 break
             case "mono.connect.widget.closed":
                 if closeHandler != nil {
                     closeHandler!()
                 }
-                self.dismiss(animated: true, completion: nil)
+                self.dismiss(animated: true, completion: { [weak self] in
+                    self?.removeScriptMessageHandler(for: userContentController)
+                })
                 break
             default:
 //                self.dismiss(animated: true, completion: nil)
                 break
             }
         }
+    }
+    
+    private func removeScriptMessageHandler(for userContentController: WKUserContentController) {
+        userContentController.removeScriptMessageHandler(forName: "mono")
     }
 }
 


### PR DESCRIPTION
Hi Team 👋🏽 

I observed the mono widget had a retain cycle after the widget was dismissed. The image attached shows the memory print when I present the modal 4 times. Each presented instance was retained.

<img width="485" alt="Screenshot 2021-10-23 at 17 10 14" src="https://user-images.githubusercontent.com/11021971/138563676-34b9d4a5-f62e-4fce-9308-0d720322e5f7.png">

**Root Cause:**

The **webView.configuration.userContentController** keeps a strong reference to it's script message handler(i.e the widget itself) so it can keep listening to script messages. This in turn prevents the **deinit** from being called.

You can read further explanation here: https://stackoverflow.com/questions/26383031/wkwebview-causes-my-view-controller-to-leak

My proposed solution was to manually remove the assigned script handler in the controllers dismiss completion handler.
