### PR TITLE
Deprecate `reauth_token` in favor of `account`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for contributing to Mono Connect iOS SDK!
 
 The Mono Connect iOS SDK makes it quick and easy to onboard users to Mono in your iOS app. We provide a out-of-the-box way to connect your users' financial details.
 
-If you're having general trouble with Mono Connect iOS SDK or your Mono integration, please reach out to us at <hi@mono.co> or come chat with us on [Slack](https://join.slack.com/t/devwithmono/shared_invite/zt-gvkqczzk-Ldt4FQpHtOL7FFTqh4Ux6A). We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
+If you're having general trouble with Mono Connect iOS SDK or your Mono integration, please reach out to us at <support@mono.co> or come chat with us on [Slack](https://join.slack.com/t/devwithmono/shared_invite/zt-gvkqczzk-Ldt4FQpHtOL7FFTqh4Ux6A). We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
 
 If you've found a bug in Mono Connect iOS SDK, please [let us know](https://github.com/withmono/connect-ios/issues/new)! You may
 also want to check out our [issue template](https://github.com/withmono/conncet-ios/tree/master/.github/ISSUE_TEMPLATE.md).

--- a/ConnectKit.podspec
+++ b/ConnectKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
 spec.name         = "ConnectKit"
-spec.version      = "2.0.0"
+spec.version      = "2.1.0"
 spec.summary      = "Connect your financial accounts via the Mono Connect Widget"
 spec.description  = <<-DESC
 The Mono Connect SDK is a quick and secure way to link bank accounts to Mono from within your iOS app. Mono Connect is a drop-in framework that handles connecting a financial institution to your app (credential validation, multi-factor authentication, error handling, etc).

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ onClose: (() -> Void?)? // optional
 onEvent: ((_ event: ConnectEvent) -> Void?)? // optional
 reference: String // optional
 accountId: String // optional
+scope: String // optional
 selectedInstitution: ConnectInstitution // optional
 ```
 #### Usage

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ class ViewController: UIViewController {
 ```
 
 ## Support
-If you're having general trouble with Mono Connect iOS SDK or your Mono integration, please reach out to us at <hi@mono.co> or come chat with us on [Slack](https://join.slack.com/t/devwithmono/shared_invite/zt-gvkqczzk-Ldt4FQpHtOL7FFTqh4Ux6A). We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
+If you're having general trouble with Mono Connect iOS SDK or your Mono integration, please reach out to us at <support@mono.co> or come chat with us on [Slack](https://join.slack.com/t/devwithmono/shared_invite/zt-gvkqczzk-Ldt4FQpHtOL7FFTqh4Ux6A). We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
 
 ## Contributing
 If you would like to contribute to the Mono Connect iOS SDK, please make sure to read our [contributor guidelines](https://github.com/withmono/connect-ios/tree/master/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
 The Mono Connect SDK is a quick and secure way to link bank accounts to Mono from within your iOS app. Mono Connect is a drop-in framework that handles connecting a financial institution to your app (credential validation, multi-factor authentication, error handling, etc).
 
 
-For accessing customer accounts and interacting with Mono's API (Identity, Transactions, Income, TransferPay) use the server-side [Mono API](https://docs.mono.co/docs/intro-to-mono-api).
+For accessing customer accounts and interacting with Mono's API (Identity, Transactions, Income, TransferPay) use the server-side [Mono API](https://docs.mono.co/api).
 
 ## Documentation
 
-For complete information about Mono Connect, head to the [docs](https://docs.mono.co/docs/intro-to-mono-connect-widget).
+For complete information about Mono Connect, head to the [docs](https://docs.mono.co/docs/financial-data/overview).
 
 
 ## Getting Started
 
-1. Register on the [Mono](https://app.withmono.com/dashboard) website and get your public and secret keys.
-2. Setup a server to [exchange tokens](https://docs.mono.co/reference/authentication-endpoint) to access user financial data with your Mono secret key.
+1. Register on the [Mono](https://app.mono.com) website and get your public and secret keys.
+2. Setup a server to [exchange tokens](https://docs.mono.co/api/bank-data/authorisation/exchange-token) to access user financial data with your Mono secret key.
 
 ## Installation
 
@@ -87,7 +87,7 @@ self.present(widget, animated: true, completion: nil)
 - [`onClose`](#onClose)
 - [`onEvent`](#onEvent)
 - [`reference`](#reference)
-- [`reauthCode`](#reauthCode)
+- [`accountId`](#accountId)
 - [`selectedInstitution`](#selectedInstitution)
 
 ### <a name="publicKey"></a> `publicKey`
@@ -104,7 +104,7 @@ let configuration = MonoConfiguration(
 ```
 
 ### <a name="customer"></a> `customer`
-**String: Required**
+**MonoCustomer: Required**
 
 ```swift
 // Existing customer
@@ -168,21 +168,30 @@ When passing a reference to the configuration it will be provided back to you on
 ```swift
 configuration.reference = "random_reference_string"
 ```
-### <a name="reauthCode"></a> `reauthCode`
+
+### <a name="accountId"></a> `accountId`
 **String: Optional**
 
 ### Re-authorizing an Account with Mono: A Step-by-Step Guide
-#### Step 1: Generate re-authorisation token
-Firstly, Make an API call to the Re-auth (Endpoint)[https://docs.mono.co/reference/reauth-code] with your desired Account ID and your mono application secret key. If successful, this will return a re-auth token.
+#### Step 1: Fetch Account ID for previously linked account
+
+Fetch the Account ID of the linked account from the [Mono dashboard](https://app.mono.co/customers) or [API](https://docs.mono.co/docs/customers).
+
+Alternatively, make an API call to the [Exchange Token Endpoint](https://api.withmono.com/v2/accounts/auth) with the code from a successful linking and your mono application secret key. If successful, this will return an Account ID.
+
 ##### Sample request:
 ```swift
 import Foundation
 
-let headers = ["accept": "application/json"]
+let headers = ["accept": "application/json", "Content-Type": "application/json", "mono-sec-key": "your_secret_key"]
 
 let request = NSMutableURLRequest(url: NSURL(string: "https://api.withmono.com/accounts/id/reauthorise")! as URL, cachePolicy: .useProtocolCachePolicy, timeoutInterval: 10.0)
 request.httpMethod = "POST"
 request.allHTTPHeaderFields = headers
+
+let body: [String: Any] = ["code": "some_code"]
+let jsonData = try? JSONSerialization.data(withJSONObject: body, options: .prettyPrinted)
+request.httpBody = jsonData 
 
 let session = URLSession.shared
 let dataTask = session.dataTask(with: request as URLRequest, completionHandler: { (data, response, error) -> Void in
@@ -199,11 +208,13 @@ dataTask.resume()
 ##### Sample response:
 ```json
 {
-  "token": "VwxcfeLRZvq1UlD5WiuN"
+  "id": "661d759280dbf646242634cc"
 }
 ```
+
 #### Step 2: Initiate your SDK with re-authorisation config option
-With step one out of the way, proceed to retrieve the re-authorisation token in the response above and pass it to your config option in your installed SDK. Implementation example provided below for an Android SDK
+With step one out of the way, pass the customer's Account ID to your config option in your installed SDK. Implementation example provided below for the iOS SDK
+
 ```swift
 let configuration = MonoConfiguration(
   publicKey: "test_pk_...", // your publicKey
@@ -211,14 +222,15 @@ let configuration = MonoConfiguration(
       print("Success with code: \(code)")
   })
   configuration.reference = "reference"
-  configuration.reauthCode = "code_xyz"
+  configuration.accountId = "account_xyz"
   configuration.onEvent = { (event) -> Void in
       print("Event Name: \(event.eventName), Event Time\(event.data.timestamp)")
       print("Event Reference: \(event.data.reference!)")
 }
 ```
+
 #### Step 3: Trigger re-authorisation widget
-In this final step, ensure the widget is triggered open. Once opened the user provides a security information which can either: password, pin, OTP, token, security answer etc.
+In this final step, ensure the widget is launched with the new config. Once opened the user provides a security information which can be: password, pin, OTP, token, security answer etc.
 If the re-authorisation process is successful, the user's account becomes re-authorised after which two things happen.
 a. The 'mono.events.account_reauthorized' webhook event is sent to the webhook URL that you specified on your dashboard app.
 b. Updated financial data gets returned on the Mono connect data APIs when an API request is been made.
@@ -251,7 +263,7 @@ onSuccesss: (_ code: String) -> Void // required
 onClose: (() -> Void?)? // optional
 onEvent: ((_ event: ConnectEvent) -> Void?)? // optional
 reference: String // optional
-reauthCode: String // optional
+accountId: String // optional
 selectedInstitution: ConnectInstitution // optional
 ```
 #### Usage
@@ -329,7 +341,7 @@ Can be `.InternetBanking` for internet banking login or `.MobileBanking` for a m
 
 On a button click, get an auth `code` for a first time user from [Mono Connect Widget](https://docs.mono.co/docs/widgets).
 
-**Note:** Exchange tokens or a `code` must be passed to your backend for final verification with your `secretKey` for you can retrieve financial information. See [Exchange Token](https://docs.mono.co/reference/authentication-endpoint).
+**Note:** Exchange tokens or a `code` must be passed to your backend for final verification with your `secretKey` for you can retrieve financial information. See [Exchange Token](https://api.withmono.com/v2/accounts/auth).
 
 ```swift
 import UIKit
@@ -368,15 +380,11 @@ class ViewController: UIViewController {
   }
 }
 ```
-##### Reauthorising an account with MFA
+##### Reauthorising an account
 
-1. First you will need to get a Reauth token on your backend with the [Reauthorise API](https://docs.mono.co/reference/reauth-code).
+1. First you will need to fetch the Account ID for the previously linked account.
 
-2. Then you have to pass this token to the frontend for user authentication. 
-
-3. Complete the reauthorisation flow by passing the token to the widget configuration and open the widget.
-
-**Note:** The reauth token expires in 10 minutes. You need to request a token on your backend and pass it to the frontend for use immediately.
+2. Then add this ID to the widget configuration object and open the widget.
 
 ```swift
 import UIKit
@@ -396,7 +404,7 @@ class ViewController: UIViewController {
       onSuccess: { code in
         print("Success with code: \(code)")
       },
-      reauthCode: "code_xyz"
+      accountId: "account_xyz"
     )
 
     let widget = Mono.reauthorise(configuration: configuration)

--- a/Sources/ConnectKit/ConnectData.swift
+++ b/Sources/ConnectKit/ConnectData.swift
@@ -8,20 +8,27 @@ import Foundation
 
 public class ConnectData {
 
-    public let type: String // type of event mono.connect.xxxx
-    public let reference: String? // reference passed through the connect setup
-    public let pageName: String? // name of page the widget exited on
-    public let prevAuthMethod: String? // auth method before it was last changed
-    public let authMethod: String? // current auth method
-    public let mfaType: String? // type of MFA the current user/bank requires
-    public let selectedAccountsCount: Int? // number of accounts selected by the user
-    public let errorType: String? // error thrown by widget
-    public let errorMessage: String? // error message describing the error
-    public let institutionId: String? // id of institution
-    public let institutionName: String? // name of institution
-    public let timestamp: Date // timestamp of the event converted to Date object
+    public let type: String  // type of event mono.connect.xxxx
+    public let reference: String?  // reference passed through the connect setup
+    public let pageName: String?  // name of page the widget exited on
+    public let prevAuthMethod: String?  // auth method before it was last changed
+    public let authMethod: String?  // current auth method
+    public let mfaType: String?  // type of MFA the current user/bank requires
+    public let selectedAccountsCount: Int?  // number of accounts selected by the user
+    public let errorType: String?  // error thrown by widget
+    public let errorMessage: String?  // error message describing the error
+    public let institutionId: String?  // id of institution
+    public let institutionName: String?  // name of institution
+    public let timestamp: Date  // timestamp of the event converted to Date object
 
-    public init(type: String, reference: String? = nil, pageName: String? = nil, prevAuthMethod: String? = nil, authMethod: String? = nil, mfaType: String? = nil, selectedAccountsCount: Int? = nil, errorType: String? = nil, errorMessage: String? = nil, institutionId: String? = nil, institutionName: String? = nil, timestamp: Date) {
+    public init(
+        type: String, reference: String? = nil, pageName: String? = nil,
+        prevAuthMethod: String? = nil, authMethod: String? = nil,
+        mfaType: String? = nil, selectedAccountsCount: Int? = nil,
+        errorType: String? = nil, errorMessage: String? = nil,
+        institutionId: String? = nil, institutionName: String? = nil,
+        timestamp: Date
+    ) {
         self.type = type
         self.reference = reference
         self.pageName = pageName

--- a/Sources/ConnectKit/ConnectEvent.swift
+++ b/Sources/ConnectKit/ConnectEvent.swift
@@ -8,12 +8,25 @@ import Foundation
 
 public class ConnectEvent {
 
-    public let eventName: String // name of event XXXXX
-    public let data: ConnectData // holds all the related data
+    public let eventName: String  // name of event XXXXX
+    public let data: ConnectData  // holds all the related data
 
-    public init(eventName: String, type: String, reference: String? = nil, pageName: String? = nil, prevAuthMethod: String? = nil, authMethod: String? = nil, mfaType: String? = nil, selectedAccountsCount: Int? = nil, errorType: String? = nil, errorMessage: String? = nil, institutionId: String? = nil, institutionName: String? = nil, timestamp: Date) {
+    public init(
+        eventName: String, type: String, reference: String? = nil,
+        pageName: String? = nil, prevAuthMethod: String? = nil,
+        authMethod: String? = nil, mfaType: String? = nil,
+        selectedAccountsCount: Int? = nil, errorType: String? = nil,
+        errorMessage: String? = nil, institutionId: String? = nil,
+        institutionName: String? = nil, timestamp: Date
+    ) {
 
-        let data = ConnectData(type: type, reference: reference, pageName: pageName, prevAuthMethod: prevAuthMethod, authMethod: authMethod, mfaType: mfaType, selectedAccountsCount: selectedAccountsCount, errorType: errorType, errorMessage: errorMessage, institutionId: institutionId, institutionName: institutionName, timestamp: timestamp)
+        let data = ConnectData(
+            type: type, reference: reference, pageName: pageName,
+            prevAuthMethod: prevAuthMethod, authMethod: authMethod,
+            mfaType: mfaType, selectedAccountsCount: selectedAccountsCount,
+            errorType: errorType, errorMessage: errorMessage,
+            institutionId: institutionId, institutionName: institutionName,
+            timestamp: timestamp)
 
         self.data = data
         self.eventName = eventName

--- a/Sources/ConnectKit/ConnectEventMapper.swift
+++ b/Sources/ConnectKit/ConnectEventMapper.swift
@@ -6,73 +6,94 @@
 
 import Foundation
 
-
-
 class ConnectEventMapper {
 
- public static var eventNames = [
-    "mono.connect.widget_opened": "OPENED",
-    "mono.connect.error_occured": "ERROR",
-    "mono.connect.institution_selected": "INSTITUTION_SELECTED",
-    "mono.connect.auth_method_switched": "AUTH_METHOD_SWITCHED",
-    "mono.connect.on_exit": "EXIT",
-    "mono.connect.login_attempt": "SUBMIT_CREDENTIALS",
-    "mono.connect.mfa_submitted": "SUBMIT_MFA",
-    "mono.connect.account_linked": "ACCOUNT_LINKED",
-    "mono.connect.account_selected": "ACCOUNT_SELECTED",
- ]
+    public static var eventNames = [
+        "mono.connect.widget_opened": "OPENED",
+        "mono.connect.error_occured": "ERROR",
+        "mono.connect.institution_selected": "INSTITUTION_SELECTED",
+        "mono.connect.auth_method_switched": "AUTH_METHOD_SWITCHED",
+        "mono.connect.on_exit": "EXIT",
+        "mono.connect.login_attempt": "SUBMIT_CREDENTIALS",
+        "mono.connect.mfa_submitted": "SUBMIT_MFA",
+        "mono.connect.account_linked": "ACCOUNT_LINKED",
+        "mono.connect.account_selected": "ACCOUNT_SELECTED",
+    ]
 
     static func map(_ dictionary: [String: Any]) -> ConnectEvent? {
 
-    // get event type
-    var type = dictionary["type"] as? String
-    if type == nil {
-        type = "UNKNOWN"
-    }
-
-    let name = eventNames[type ?? "UNKNOWN", default: "UNKNOWN"]
-
-    // get data variables
-    if let data = dictionary["data"] as? [String : Any] {
-        let reference = extractProperty(name: "reference", data: data) as? String
-        let pageName = extractProperty(name: "pageName", data: data) as? String
-        let prevAuthMethod = extractProperty(name: "prevAuthMethod", data: data) as? String
-        let authMethod = extractProperty(name: "authMethod", data: data) as? String
-        let mfaType = extractProperty(name: "mfaType", data: data) as? String
-        let selectedAccountsCount = extractProperty(name: "selectedAccountsCount", data: data) as? Int
-        let errorType = extractProperty(name: "errorType", data: data) as? String
-        let errorMessage = extractProperty(name: "errorMessage", data: data) as? String
-
-        // get institution
-        let institutionData = data["institution"] as? [String : Any]
-        var institutionId: String? = ""
-        var institutionName: String? = ""
-        if institutionData != nil {
-            institutionId = (extractProperty(name: "id", data: institutionData!) as? String)!
-            institutionName = (extractProperty(name: "name", data: institutionData!) as? String)!
-        }else{
-            institutionId = nil
-            institutionName = nil
+        // get event type
+        var type = dictionary["type"] as? String
+        if type == nil {
+            type = "UNKNOWN"
         }
 
-        var unixTimestamp = extractProperty(name: "timestamp", data: data) as? Int
-        if unixTimestamp != nil {
-            unixTimestamp = unixTimestamp! / 1000
-        }else{
-            unixTimestamp = Int(Date().timeIntervalSince1970)
+        let name = eventNames[type ?? "UNKNOWN", default: "UNKNOWN"]
+
+        // get data variables
+        if let data = dictionary["data"] as? [String: Any] {
+            let reference =
+                extractProperty(name: "reference", data: data) as? String
+            let pageName =
+                extractProperty(name: "pageName", data: data) as? String
+            let prevAuthMethod =
+                extractProperty(name: "prevAuthMethod", data: data) as? String
+            let authMethod =
+                extractProperty(name: "authMethod", data: data) as? String
+            let mfaType =
+                extractProperty(name: "mfaType", data: data) as? String
+            let selectedAccountsCount =
+                extractProperty(name: "selectedAccountsCount", data: data)
+                as? Int
+            let errorType =
+                extractProperty(name: "errorType", data: data) as? String
+            let errorMessage =
+                extractProperty(name: "errorMessage", data: data) as? String
+
+            // get institution
+            let institutionData = data["institution"] as? [String: Any]
+            var institutionId: String? = ""
+            var institutionName: String? = ""
+            if institutionData != nil {
+                institutionId =
+                    (extractProperty(name: "id", data: institutionData!)
+                    as? String)!
+                institutionName =
+                    (extractProperty(name: "name", data: institutionData!)
+                    as? String)!
+            } else {
+                institutionId = nil
+                institutionName = nil
+            }
+
+            var unixTimestamp =
+                extractProperty(name: "timestamp", data: data) as? Int
+            if unixTimestamp != nil {
+                unixTimestamp = unixTimestamp! / 1000
+            } else {
+                unixTimestamp = Int(Date().timeIntervalSince1970)
+            }
+
+            let timestamp = Date(
+                timeIntervalSince1970: TimeInterval(unixTimestamp!))
+
+            return ConnectEvent(
+                eventName: name, type: type ?? "UNKNOWN", reference: reference,
+                pageName: pageName, prevAuthMethod: prevAuthMethod,
+                authMethod: authMethod, mfaType: mfaType,
+                selectedAccountsCount: selectedAccountsCount,
+                errorType: errorType, errorMessage: errorMessage,
+                institutionId: institutionId, institutionName: institutionName,
+                timestamp: timestamp)
+
+        } else {
+            return ConnectEvent(
+                eventName: name, type: type ?? "UNKNOWN", timestamp: Date())
         }
-
-        let timestamp = Date(timeIntervalSince1970: TimeInterval(unixTimestamp!))
-
-        return ConnectEvent(eventName: name, type: type ?? "UNKNOWN", reference: reference, pageName: pageName, prevAuthMethod: prevAuthMethod, authMethod: authMethod, mfaType: mfaType, selectedAccountsCount: selectedAccountsCount, errorType: errorType, errorMessage: errorMessage, institutionId: institutionId, institutionName: institutionName, timestamp: timestamp)
-
-    }else{
-        return ConnectEvent(eventName: name, type: type ?? "UNKNOWN", timestamp: Date())
     }
-  }
 
-  static func extractProperty(name: String, data: [String : Any]) -> Any {
-    let reference = data[name]
-    return reference as Any
-  }
+    static func extractProperty(name: String, data: [String: Any]) -> Any {
+        let reference = data[name]
+        return reference as Any
+    }
 }

--- a/Sources/ConnectKit/ConnectInstitution.swift
+++ b/Sources/ConnectKit/ConnectInstitution.swift
@@ -1,6 +1,6 @@
 //
 //  ConnectInstitution.swift
-//  
+//
 //
 //  Created by Tristan Tsvetanov on 02021-07-19.
 //
@@ -8,31 +8,31 @@
 import Foundation
 
 public struct ConnectInstitution: Codable {
-    
-    public let id: String // institution id in Mono DB
-    public let authMethod: String // enum representing possible authentication methods
+
+    public let id: String  // institution id in Mono DB
+    public let authMethod: String  // enum representing possible authentication methods
 
     public init(id: String, authMethod: ConnectAuthMethod) {
         self.id = id
-        
+
         switch authMethod {
-        
+
         case .InternetBanking:
             self.authMethod = "internet_banking"
-            
+
         case .MobileBanking:
             self.authMethod = "mobile_banking"
-            
+
         default:
             self.authMethod = "internet_banking"
-            
+
         }
-        
+
     }
 
     enum CodingKeys: String, CodingKey {
         case id
         case authMethod = "auth_method"
     }
-    
+
 }

--- a/Sources/ConnectKit/Mono.swift
+++ b/Sources/ConnectKit/Mono.swift
@@ -9,30 +9,38 @@ import UIKit
 
 public class Mono {
 
-    init(){ }
-    
-    public static func create(configuration: MonoConfiguration) -> UIViewController {
-        let flagError = configuration.reauthCode != nil
-        
-        if flagError{
-            print("You cannot pass a reauthCode: String to the default create function, use Mono.reauthorise() instead.")
-        }
-        
-        let widget = MonoWidget(configuration: configuration)
+    init() {}
 
-        return widget
-    }
-    
-    public static func reauthorise(configuration: MonoConfiguration) -> UIViewController {
-        let flagError = configuration.reauthCode == nil
-        
+    public static func create(configuration: MonoConfiguration)
+        -> UIViewController
+    {
+        let flagError = configuration.accountId != nil
+
         if flagError {
-            print("Reauthorisation requires you to pass a reauthCode: String to the configuration object.")
+            print(
+                "You cannot pass an accountId: String to the default create function, use Mono.reauthorise() instead."
+            )
         }
-        
+
         let widget = MonoWidget(configuration: configuration)
 
         return widget
     }
-    
+
+    public static func reauthorise(configuration: MonoConfiguration)
+        -> UIViewController
+    {
+        let flagError = configuration.accountId == nil
+
+        if flagError {
+            print(
+                "Reauthorisation requires you to pass an accountId: String to the configuration object."
+            )
+        }
+
+        let widget = MonoWidget(configuration: configuration)
+
+        return widget
+    }
+
 }

--- a/Sources/ConnectKit/MonoConfiguration.swift
+++ b/Sources/ConnectKit/MonoConfiguration.swift
@@ -12,15 +12,22 @@ public class MonoConfiguration {
     public var publicKey: String
     public var onSuccess: ((_ authCode: String) -> Void?)
     public var customer: MonoCustomer
-    
+
     // optional parameters
     public var reference: String?
     public var onClose: (() -> Void?)?
     public var onEvent: ((_ event: ConnectEvent) -> Void?)?
-    public var reauthCode: String?
+    public var accountId: String?
     public var selectedInstitution: ConnectInstitution?
 
-    public init(publicKey: String, customer: MonoCustomer, onSuccess: @escaping ((_ authCode: String) -> Void?), reference: String? = nil, reauthCode: String? = nil, onClose: (() -> Void?)? = nil, onEvent: ((_ event: ConnectEvent) -> Void?)? = nil, selectedInstitution: ConnectInstitution? = nil){
+    public init(
+        publicKey: String, customer: MonoCustomer,
+        onSuccess: @escaping ((_ authCode: String) -> Void?),
+        reference: String? = nil, accountId: String? = nil,
+        onClose: (() -> Void?)? = nil,
+        onEvent: ((_ event: ConnectEvent) -> Void?)? = nil,
+        selectedInstitution: ConnectInstitution? = nil
+    ) {
 
         self.publicKey = publicKey
         self.onSuccess = onSuccess
@@ -28,27 +35,27 @@ public class MonoConfiguration {
 
         if onClose != nil {
             self.onClose = onClose!
-        }else{
+        } else {
             self.onClose = nil
         }
         if onEvent != nil {
             self.onEvent = onEvent!
-        }else{
+        } else {
             self.onEvent = nil
         }
         if reference != nil {
             self.reference = reference
-        }else{
+        } else {
             self.reference = nil
         }
-        if reauthCode != nil {
-            self.reauthCode = reauthCode
-        }else{
-            self.reauthCode = nil
+        if accountId != nil {
+            self.accountId = accountId
+        } else {
+            self.accountId = nil
         }
         if selectedInstitution != nil {
             self.selectedInstitution = selectedInstitution
-        }else{
+        } else {
             self.selectedInstitution = nil
         }
 

--- a/Sources/ConnectKit/MonoConfiguration.swift
+++ b/Sources/ConnectKit/MonoConfiguration.swift
@@ -18,12 +18,16 @@ public class MonoConfiguration {
     public var onClose: (() -> Void?)?
     public var onEvent: ((_ event: ConnectEvent) -> Void?)?
     public var accountId: String?
+    public var scope: String?
     public var selectedInstitution: ConnectInstitution?
 
     public init(
-        publicKey: String, customer: MonoCustomer,
+        publicKey: String,
+        customer: MonoCustomer,
         onSuccess: @escaping ((_ authCode: String) -> Void?),
-        reference: String? = nil, accountId: String? = nil,
+        reference: String? = nil,
+        accountId: String? = nil,
+        scope: String? = nil,
         onClose: (() -> Void?)? = nil,
         onEvent: ((_ event: ConnectEvent) -> Void?)? = nil,
         selectedInstitution: ConnectInstitution? = nil
@@ -52,6 +56,11 @@ public class MonoConfiguration {
             self.accountId = accountId
         } else {
             self.accountId = nil
+        }
+        if scope != nil {
+            self.scope = scope
+        } else {
+            self.scope = nil
         }
         if selectedInstitution != nil {
             self.selectedInstitution = selectedInstitution

--- a/Sources/ConnectKit/MonoCustomer.swift
+++ b/Sources/ConnectKit/MonoCustomer.swift
@@ -5,12 +5,16 @@ public struct MonoCustomer: Codable {
     public let name: String?
     public let email: String?
     public let identity: MonoCustomerIdentity?
-    
-    public init(id: String? = nil, name: String? = nil, email: String? = nil, identity: MonoCustomerIdentity? = nil) {
+
+    public init(
+        id: String? = nil, name: String? = nil, email: String? = nil,
+        identity: MonoCustomerIdentity? = nil
+    ) {
         // Validate that name and email are provided when id is not passed
         if id == nil {
             guard let providedName = name, let providedEmail = email else {
-                fatalError("Both name and email are required when id is not provided.")
+                fatalError(
+                    "Both name and email are required when id is not provided.")
             }
             self.name = providedName
             self.email = providedEmail
@@ -18,11 +22,11 @@ public struct MonoCustomer: Codable {
             self.name = name
             self.email = email
         }
-        
+
         self.identity = identity
         self.id = id
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case id
         case name
@@ -34,12 +38,12 @@ public struct MonoCustomer: Codable {
 public struct MonoCustomerIdentity: Codable {
     public let number: String
     public let type: String
-    
+
     public init(type: String, number: String) {
         self.number = number
         self.type = type
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case type
         case number

--- a/Sources/ConnectKit/MonoWidget.swift
+++ b/Sources/ConnectKit/MonoWidget.swift
@@ -11,7 +11,10 @@ import WebKit
 public class MonoWidget: UIViewController, WKUIDelegate {
 
     // contants
-    let DEPRECATED_EVENTS = ["mono.connect.widget.closed", "mono.connect.widget.account_linked", "mono.modal.closed", "mono.modal.linked"]
+    let DEPRECATED_EVENTS = [
+        "mono.connect.widget.closed", "mono.connect.widget.account_linked",
+        "mono.modal.closed", "mono.modal.linked",
+    ]
 
     // required
     var publicKey: String
@@ -20,7 +23,7 @@ public class MonoWidget: UIViewController, WKUIDelegate {
 
     // optionals
     var reference: String?
-    var code: String?
+    var accountId: String?
     var selectedInstitution: ConnectInstitution?
 
     // handlers
@@ -38,32 +41,32 @@ public class MonoWidget: UIViewController, WKUIDelegate {
         self.customer = configuration.customer
 
         // optionals
-        if configuration.reauthCode != nil {
-            self.code = configuration.reauthCode
-        }else{
-            self.code = nil
+        if configuration.accountId != nil {
+            self.accountId = configuration.accountId
+        } else {
+            self.accountId = nil
         }
         if configuration.reference != nil {
             self.reference = configuration.reference
-        }else{
+        } else {
             self.reference = nil
         }
         if configuration.selectedInstitution != nil {
             self.selectedInstitution = configuration.selectedInstitution
-        }else{
+        } else {
             self.selectedInstitution = nil
         }
 
         // handlers
-        if(configuration.onClose != nil){
+        if configuration.onClose != nil {
             self.closeHandler = configuration.onClose!
-        }else{
+        } else {
             self.closeHandler = nil
         }
 
-        if(configuration.onEvent != nil){
+        if configuration.onEvent != nil {
             self.eventHandler = configuration.onEvent!
-        }else{
+        } else {
             self.eventHandler = nil
         }
 
@@ -71,7 +74,8 @@ public class MonoWidget: UIViewController, WKUIDelegate {
         self.progressView.sizeToFit()
         super.init(nibName: nil, bundle: nil)
 
-        self.progressView.frame = CGRect(x: 0, y: 0, width: self.view.frame.width * 2, height: 2)
+        self.progressView.frame = CGRect(
+            x: 0, y: 0, width: self.view.frame.width * 2, height: 2)
     }
 
     required init?(coder: NSCoder) {
@@ -79,8 +83,8 @@ public class MonoWidget: UIViewController, WKUIDelegate {
     }
 
     deinit {
-       webView.removeObserver(self, forKeyPath: "estimatedProgress")
-       progressView.removeFromSuperview()
+        webView.removeObserver(self, forKeyPath: "estimatedProgress")
+        progressView.removeFromSuperview()
     }
 
     lazy var webView: WKWebView = {
@@ -89,12 +93,17 @@ public class MonoWidget: UIViewController, WKUIDelegate {
         webView.uiDelegate = self
         webView.navigationDelegate = self
         webView.translatesAutoresizingMaskIntoConstraints = false
-        webView.addObserver(self, forKeyPath: #keyPath(WKWebView.estimatedProgress), options: .new, context: nil)
+        webView.addObserver(
+            self, forKeyPath: #keyPath(WKWebView.estimatedProgress),
+            options: .new, context: nil)
 
         return webView
     }()
 
-    override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    override public func observeValue(
+        forKeyPath keyPath: String?, of object: Any?,
+        change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?
+    ) {
 
         if keyPath == "estimatedProgress" {
             let progressFloat = Float(webView.estimatedProgress)
@@ -110,56 +119,59 @@ public class MonoWidget: UIViewController, WKUIDelegate {
         contentController.add(self, name: "mono")
 
         var components = URLComponents()
-        components.scheme="https"
-        components.host="connect.mono.co"
+        components.scheme = "https"
+        components.host = "connect.mono.co"
         let queryItemKey = URLQueryItem(name: "key", value: publicKey)
-        let queryItemVersion = URLQueryItem(name: "version", value: "2023-12-14")
-        let queryScope = URLQueryItem(name: "scope", value: "auth")
+        let queryItemVersion = URLQueryItem(
+            name: "version", value: "2023-12-14")
+        let queryScope = URLQueryItem(
+            name: "scope",
+            value: accountId != nil ? "reauth" : "auth"
+        )
         var qs = [queryItemKey, queryItemVersion, queryScope]
 
         do {
             let jsonEncoder = JSONEncoder()
-            let data = WidgetData(customer: customer)
+            let data = WidgetData(customer: customer, account: accountId)
             let jsonData = try jsonEncoder.encode(data)
             let json = String(data: jsonData, encoding: String.Encoding.utf8)
-            
+
             let queryItemCode = URLQueryItem(name: "data", value: json)
             qs.append(queryItemCode)
-        }
-        catch {
+        } catch {
             print("error = \(error.localizedDescription)")
         }
 
-        if(code != nil) {
-          let queryItemCode = URLQueryItem(name: "reauth_token", value: code)
-          qs.append(queryItemCode)
-        }
-        if(reference != nil) {
-            let queryItemCode = URLQueryItem(name: "reference", value: reference)
+        if reference != nil {
+            let queryItemCode = URLQueryItem(
+                name: "reference", value: reference)
             qs.append(queryItemCode)
         }
-        if(selectedInstitution != nil){
+        if selectedInstitution != nil {
             do {
                 let jsonEncoder = JSONEncoder()
                 let jsonData = try jsonEncoder.encode(selectedInstitution)
-                let json = String(data: jsonData, encoding: String.Encoding.utf8)
+                let json = String(
+                    data: jsonData, encoding: String.Encoding.utf8)
 
-                let queryItemCode = URLQueryItem(name: "selectedInstitution", value: json)
+                let queryItemCode = URLQueryItem(
+                    name: "selectedInstitution", value: json)
                 qs.append(queryItemCode)
-            }
-            catch {
+            } catch {
                 print("error = \(error.localizedDescription)")
             }
 
         }
 
-        components.queryItems = qs;
+        components.queryItems = qs
 
         let request = URLRequest(url: components.url!)
         webView.load(request)
 
-        if self.eventHandler != nil{
-            let connectEvent = ConnectEvent(eventName: "OPENED", type: "mono.connect.widget_opened", reference: self.reference, timestamp: Date())
+        if self.eventHandler != nil {
+            let connectEvent = ConnectEvent(
+                eventName: "OPENED", type: "mono.connect.widget_opened",
+                reference: self.reference, timestamp: Date())
             self.eventHandler!(connectEvent)
         }
 
@@ -173,14 +185,19 @@ public class MonoWidget: UIViewController, WKUIDelegate {
         if #available(iOS 11.0, *) {
             NSLayoutConstraint.activate([
                 webView.topAnchor
-                    .constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+                    .constraint(
+                        equalTo: self.view.safeAreaLayoutGuide.topAnchor),
                 webView.leftAnchor
-                    .constraint(equalTo: self.view.safeAreaLayoutGuide.leftAnchor),
+                    .constraint(
+                        equalTo: self.view.safeAreaLayoutGuide.leftAnchor),
                 webView.bottomAnchor
-                    .constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+                    .constraint(
+                        equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
                 webView.rightAnchor
-                    .constraint(equalTo: self.view.safeAreaLayoutGuide.rightAnchor)
+                    .constraint(
+                        equalTo: self.view.safeAreaLayoutGuide.rightAnchor),
             ])
+            
         } else {
             // Fallback on earlier versions
         }
@@ -191,7 +208,9 @@ extension MonoWidget: WKScriptMessageHandler {
     public func parseJSON(str: String?) -> [String: AnyObject]? {
         if let data = str?.data(using: .utf8) {
             do {
-                let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: AnyObject]
+                let json =
+                    try JSONSerialization.jsonObject(with: data, options: [])
+                    as? [String: AnyObject]
                 return json
             } catch let error as NSError {
                 print("Failed to load: \(error.localizedDescription)")
@@ -202,13 +221,18 @@ extension MonoWidget: WKScriptMessageHandler {
         return nil
     }
 
-    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        if message.name == "mono", let messageBody = parseJSON(str: (message.body as! String)){
+    public func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        if message.name == "mono",
+            let messageBody = parseJSON(str: (message.body as! String))
+        {
             let data = messageBody["data"] as? [String: Any]
             let type = messageBody["type"] as! String
 
             // pass data on to onEvent
-            if self.eventHandler != nil && !DEPRECATED_EVENTS.contains(type){
+            if self.eventHandler != nil && !DEPRECATED_EVENTS.contains(type) {
                 let connectEvent = ConnectEventMapper.map(messageBody)
                 self.eventHandler!(connectEvent!)
             }
@@ -233,35 +257,63 @@ extension MonoWidget: WKScriptMessageHandler {
 }
 
 extension MonoWidget: WKNavigationDelegate {
-    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        webView.evaluateJavaScript("window.MonoClientInterface = window.webkit.messageHandlers.mono;")
+    public func webView(
+        _ webView: WKWebView, didFinish navigation: WKNavigation!
+    ) {
+        webView.evaluateJavaScript(
+            "window.MonoClientInterface = window.webkit.messageHandlers.mono;")
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: {
-            self.progressView.isHidden = true;
-        })
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + 0.5,
+            execute: {
+                self.progressView.isHidden = true
+            })
     }
 
-    public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+    public func webView(
+        _ webView: WKWebView,
+        didStartProvisionalNavigation navigation: WKNavigation!
+    ) {
         progressView.isHidden = false
     }
 
-    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error){
+    public func webView(
+        _ webView: WKWebView, didFail navigation: WKNavigation!,
+        withError error: Error
+    ) {
         self.dismiss(animated: true, completion: nil)
     }
 
-    public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+    public func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
         self.dismiss(animated: true, completion: nil)
     }
 }
 
 public struct WidgetData: Codable {
     public let customer: MonoCustomer
+    public var account: String?
 
-    public init(customer: MonoCustomer) {
+    public init(customer: MonoCustomer, account: String? = nil) {
         self.customer = customer
+        self.account = account
     }
     
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        
+        try container.encode(customer, forKey: .customer)
+        
+        if let account = account {
+            try container.encode(account, forKey: .account)
+        }
+    }
+
     enum CodingKeys: String, CodingKey {
         case customer
-   }
+        case account
+    }
 }

--- a/Sources/ConnectKit/MonoWidget.swift
+++ b/Sources/ConnectKit/MonoWidget.swift
@@ -24,6 +24,7 @@ public class MonoWidget: UIViewController, WKUIDelegate {
     // optionals
     var reference: String?
     var accountId: String?
+    var scope: String?
     var selectedInstitution: ConnectInstitution?
 
     // handlers
@@ -45,6 +46,11 @@ public class MonoWidget: UIViewController, WKUIDelegate {
             self.accountId = configuration.accountId
         } else {
             self.accountId = nil
+        }
+        if configuration.scope != nil {
+            self.scope = configuration.scope
+        } else {
+            self.scope = nil
         }
         if configuration.reference != nil {
             self.reference = configuration.reference
@@ -124,9 +130,11 @@ public class MonoWidget: UIViewController, WKUIDelegate {
         let queryItemKey = URLQueryItem(name: "key", value: publicKey)
         let queryItemVersion = URLQueryItem(
             name: "version", value: "2023-12-14")
+        
+        let resolvedScope = accountId != nil && (scope == nil || scope == "auth") ? "reauth" : scope
         let queryScope = URLQueryItem(
             name: "scope",
-            value: accountId != nil ? "reauth" : "auth"
+            value: resolvedScope ?? "auth"
         )
         var qs = [queryItemKey, queryItemVersion, queryScope]
 


### PR DESCRIPTION
This PR replaces `reauth_token` with `account` for account re-authorisation. The `account` field takes the Account ID of a previously linked account and passes that to the Connect Widget which then handles re-authorisation. This eliminates the need for partners to make an extra call to the [reauthorise endpoint](https://docs.mono.co/api/bank-data/reauth) for a `reauth_token`.


https://github.com/user-attachments/assets/bdf702d2-00a8-4d3f-b0fa-ebafefa49cfd

