### PR TITLE
Mono fx add camera usage configuration to README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ The Mono Connect iOS SDK makes it quick and easy to onboard users to Mono in you
 If you're having general trouble with Mono Connect iOS SDK or your Mono integration, please reach out to us at <support@mono.co> or come chat with us on [Slack](https://join.slack.com/t/devwithmono/shared_invite/zt-gvkqczzk-Ldt4FQpHtOL7FFTqh4Ux6A). We're proud of our level of service, and we're more than happy to help you out with your integration to Mono.
 
 If you've found a bug in Mono Connect iOS SDK, please [let us know](https://github.com/withmono/connect-ios/issues/new)! You may
-also want to check out our [issue template](https://github.com/withmono/conncet-ios/tree/master/.github/ISSUE_TEMPLATE.md).
+also want to check out our [issue template](https://github.com/withmono/connect-ios/tree/master/.github/ISSUE_TEMPLATE.md).
 
 ## Code review
 

--- a/README.md
+++ b/README.md
@@ -25,23 +25,19 @@ Go to File -> Swift Packages -> Add Package Dependency...
 
 Then enter the URL for this package `https://github.com/withmono/connect-ios.git` and select the most recent version.
 
-<!--
-
-Install the package with:
-
-```sh
-npm install mono-node --save
-# or
-yarn add mono-node
-```
-
--->
-
 ## Requirements
 
 - Xcode 11.0 or greater
 - iOS 9.0 or greater
 - The latest version of the ConnectKit
+- Add the key `Privacy - Camera Usage Description` and a usage description to your `Info.plist`.
+
+If editing `Info.plist` as text, add:
+
+```xml
+<key>NSCameraUsageDescription</key>
+<string>your usage description here</string>
+```
 
 ## To build without Rosetta
 To resolve the missing architecture issue when building on M1 and M2 Macs, please follow these instructions, particularly when building for simulator devices:


### PR DESCRIPTION
This PR updates our README with the steps to configure camera usage in an app's `Info.plist` file.